### PR TITLE
Changes made to TestRunner.template and SourcePaths.java 

### DIFF
--- a/FlexUnit4AntTasks/src/TestRunner.template
+++ b/FlexUnit4AntTasks/src/TestRunner.template
@@ -19,6 +19,7 @@ creationComplete="runTests();">
 					null, 
 [@CLASS_REFS@]
 				);
+			core.addUncaughtErrorListener( systemManager.loaderInfo );
             core.run(request);
          }
       ]]>

--- a/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/types/SourcePaths.java
+++ b/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/types/SourcePaths.java
@@ -66,7 +66,8 @@ public class SourcePaths extends CompilationFileSetCollection
             String pathWithOutSuffix = file.substring(0, file.lastIndexOf('.'));
             String canonicalClassName = pathWithOutSuffix.replace(File.separatorChar, '.');
             String className = canonicalClassName.substring(canonicalClassName.lastIndexOf('.') + 1, canonicalClassName.length());
-            elements.append(className);
+//            elements.append(className);
+            elements.append(canonicalClassName);
             elements.append(',');
          }
       }


### PR DESCRIPTION
Hi All-

Mike L. had asked me to make some changes to the FlexUnit4AntTasks project to rectify a couple of issues. Those two issues are as follows:
- Adding an 'addUncaughtErrorListener' handler to the 'core' object found in TestRunner.template
- Modifying the 'getClasses' method in SourcePaths.java to use the canonical class name as opposed to the standard/regular class name, in order to avoid naming collisions in TestRunner.mxml.

I have tested and debugged the FlexUnit ant task locally and everything seems to be working properly with the new changes. If you find any problems or issues, however, please let me know and I'll make the necessary fixes/changes.

Thanks,

Thomas
