### PR TITLE
Working timeout for hanging tests and passing arguments to ADL

### DIFF
--- a/FlexUnit4AntTasks/src/org/flexunit/ant/FlexUnitSocketServer.java
+++ b/FlexUnit4AntTasks/src/org/flexunit/ant/FlexUnitSocketServer.java
@@ -106,6 +106,7 @@ public class FlexUnitSocketServer
       
       // This method blocks until a connection is made.
       clientSocket = serverSocket.accept();
+      clientSocket.setSoTimeout(timeout);
 
       LoggingUtil.log("Client connected.");
       LoggingUtil.log("Setting inbound buffer size to [" + inboundBufferSize + "] bytes.");

--- a/FlexUnit4AntTasks/src/org/flexunit/ant/launcher/commands/player/AdlCommand.java
+++ b/FlexUnit4AntTasks/src/org/flexunit/ant/launcher/commands/player/AdlCommand.java
@@ -1,6 +1,7 @@
 package org.flexunit.ant.launcher.commands.player;
 
 import java.io.File;
+import java.util.Vector;
 
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.taskdefs.Java;
@@ -11,6 +12,7 @@ import org.apache.tools.ant.types.resources.FileResource;
 import org.apache.tools.ant.types.resources.URLResource;
 import org.apache.tools.ant.util.ResourceUtils;
 import org.flexunit.ant.LoggingUtil;
+import org.flexunit.ant.tasks.configuration.AirArgument;
 
 public class AdlCommand extends DefaultPlayerCommand
 {
@@ -19,7 +21,8 @@ public class AdlCommand extends DefaultPlayerCommand
    private final String DESCRIPTOR_FILE = "flexUnitDescriptor.xml";
 
    private File precompiledAppDescriptor;
-
+   private Vector<AirArgument> airArguments;
+   
    @Override
    public File getFileToExecute()
    {
@@ -123,6 +126,16 @@ public class AdlCommand extends DefaultPlayerCommand
       getCommandLine().setExecutable(generateExecutable());
       getCommandLine().addArguments(new String[]{getFileToExecute().getAbsolutePath()});
 
+      Vector<AirArgument> airArgs = getAirArguments();
+      if (airArgs != null)
+      {
+          getCommandLine().addArguments(new String[]{"--"});
+          for (AirArgument arg : airArgs)
+          {
+              getCommandLine().addArguments(new String[]{arg.getValue()});
+          }
+      }
+      
       if(getPrecompiledAppDescriptor() == null)
       {
     	  //Create Adl descriptor file
@@ -143,5 +156,15 @@ public class AdlCommand extends DefaultPlayerCommand
    public void setPrecompiledAppDescriptor(File precompiledAppDescriptor)
    {
 	   this.precompiledAppDescriptor = precompiledAppDescriptor;
+   }
+   
+   public Vector<AirArgument> getAirArguments()
+   {
+       return airArguments;
+   }
+   
+   public void setAirArguments(Vector<AirArgument> airArguments)
+   {
+       this.airArguments = airArguments;
    }
 }

--- a/FlexUnit4AntTasks/src/org/flexunit/ant/launcher/commands/player/CustomPlayerCommand.java
+++ b/FlexUnit4AntTasks/src/org/flexunit/ant/launcher/commands/player/CustomPlayerCommand.java
@@ -74,7 +74,7 @@ public class CustomPlayerCommand implements PlayerCommand
 
    }
    
-   public Process launch() throws IOException
+   public Process launch(long timeoutMsec) throws IOException
    {
       LoggingUtil.log(proxiedCommand.getCommandLine().describeCommand());
       

--- a/FlexUnit4AntTasks/src/org/flexunit/ant/launcher/commands/player/DefaultPlayerCommand.java
+++ b/FlexUnit4AntTasks/src/org/flexunit/ant/launcher/commands/player/DefaultPlayerCommand.java
@@ -50,8 +50,8 @@ public abstract class DefaultPlayerCommand extends Command implements PlayerComm
    public abstract void prepare();
    
    @Override
-   public Process launch() throws IOException
+   public Process launch(long timeoutMsec) throws IOException
    {
-      return super.launch();
+       return super.launch(timeoutMsec);
    }
 }

--- a/FlexUnit4AntTasks/src/org/flexunit/ant/launcher/commands/player/PlayerCommand.java
+++ b/FlexUnit4AntTasks/src/org/flexunit/ant/launcher/commands/player/PlayerCommand.java
@@ -18,5 +18,14 @@ public interface PlayerCommand
    public void setSwf(File swf);
    public void setUrl(String url);
    public void prepare();
-   public Process launch() throws IOException;
+   /**
+    * Launches the player.  Depending on the implementation, this call will
+    * either block until the player exits, in which cases the return value
+    * is null, or return an asynchronous Process object.  Only when blocking
+    * is the timeout parameter respected.
+    * @param timeoutMsec The maximum amount of time to wait for the call to
+    * return.
+    * @throws IOException Thrown on launch failure, including timeout
+    */
+   public Process launch(long timeoutMsec) throws IOException;
 }

--- a/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/FlexUnitTask.java
+++ b/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/FlexUnitTask.java
@@ -5,6 +5,7 @@ import org.apache.tools.ant.DynamicElement;
 import org.apache.tools.ant.Project;
 import org.apache.tools.ant.Task;
 import org.apache.tools.ant.types.FileSet;
+import org.flexunit.ant.tasks.configuration.AirArgument;
 import org.flexunit.ant.tasks.configuration.TaskConfiguration;
 import org.flexunit.ant.tasks.types.LoadConfig;
 
@@ -120,6 +121,13 @@ public class FlexUnitTask extends Task implements DynamicElement
    public void setPlayer(String player)
    {
       configuration.setPlayer(player);
+   }
+   
+   public AirArgument createAirArgument()
+   {
+       AirArgument argument = new AirArgument();
+       configuration.addAirArgument(argument);
+       return argument;
    }
 
    public void setCommand(String executableFilePath)

--- a/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/TestRun.java
+++ b/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/TestRun.java
@@ -50,7 +50,7 @@ public class TestRun
          //start the execution context
          context.start();
          
-         //launch the player
+         // launch the player
          Process process = player.launch();
 
          // block until daemon is completely done with all test data
@@ -89,7 +89,9 @@ public class TestRun
       
       if(command instanceof AdlCommand) 
       {
-    	  ((AdlCommand)command).setPrecompiledAppDescriptor(configuration.getPrecompiledAppDescriptor());
+          AdlCommand adlCommand = (AdlCommand)command;
+          adlCommand.setPrecompiledAppDescriptor(configuration.getPrecompiledAppDescriptor());
+          adlCommand.setAirArguments(configuration.getAirArguments());
       }
       
       return command;

--- a/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/TestRun.java
+++ b/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/TestRun.java
@@ -50,8 +50,10 @@ public class TestRun
          //start the execution context
          context.start();
          
-         // launch the player
-         Process process = player.launch();
+         // launch the player.  Note, this is sometimes a blocking call
+         // and sometimes not, depending on the player configuration.  If
+         // blocking, process will be 'null'.
+         Process process = player.launch(configuration.getSocketTimeout());
 
          // block until daemon is completely done with all test data
          daemon.get();

--- a/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/configuration/AirArgument.java
+++ b/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/configuration/AirArgument.java
@@ -1,0 +1,21 @@
+
+package org.flexunit.ant.tasks.configuration;
+
+public class AirArgument
+{
+    String value;
+    
+    public AirArgument()
+    {
+    }
+    
+    public void setValue(String value)
+    {
+        this.value = value;
+    }
+    
+    public String getValue()
+    {
+        return value;
+    }
+}

--- a/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/configuration/TaskConfiguration.java
+++ b/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/configuration/TaskConfiguration.java
@@ -100,6 +100,11 @@ public class TaskConfiguration
    {
       this.player = player;
    }
+   
+   public void addAirArgument(AirArgument airArgument)
+   {
+       testRunConfiguration.addAirArgument(airArgument);
+   }
 
    public void setPort(int port)
    {

--- a/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/configuration/TestRunConfiguration.java
+++ b/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/configuration/TestRunConfiguration.java
@@ -1,6 +1,7 @@
 package org.flexunit.ant.tasks.configuration;
 
 import java.io.File;
+import java.util.Vector;
 
 import org.apache.tools.ant.BuildException;
 import org.flexunit.ant.LoggingUtil;
@@ -12,6 +13,7 @@ public class TestRunConfiguration implements StepConfiguration
    private final int SHORTEST_SOCKET_TIMEOUT = 5000; //ms
 
    private String player;
+   private Vector<AirArgument> airArguments;
    private File command = null;
    private int display = 99;
    private boolean failOnTestFailure = false;
@@ -123,6 +125,20 @@ public class TestRunConfiguration implements StepConfiguration
       return port;
    }
 
+   public void addAirArgument(AirArgument airArgument)
+   {
+       if (airArguments == null)
+       {
+           airArguments = new Vector<AirArgument>();
+       }
+       airArguments.add(airArgument);
+   }
+   
+   public Vector<AirArgument> getAirArguments()
+   {
+       return airArguments;
+   }
+   
    public void setPort(int port)
    {
       this.port = port;


### PR DESCRIPTION
Hi there-

I believe I've fixed the timeout support for players that hang.  Flash and AIR players are using Execute to launch, and now will have an ExecuteWatchdog set on them to kill them if they don't exit within the time set by the flexunit ant task.  I also added a socket timeout to the accepted connection to the test (there already was a timeout on the server socket).  This should catch hanging 'custom command' players as well.

Also, I added a way to pass arguments from the flexunit ant task to the ADL player.  I needed this because I'm using the flexcover-to-emma integration described at eyefodder.com, which requires passing some args to tell flexcover where to write the output files.

This is my first use of github, so apologies if I've done something not-quite-right.

Richard
