### PR TITLE
Adds the ability to specify jvm arguments to use for the mxmlc command.

### DIFF
--- a/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/Compilation.java
+++ b/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/Compilation.java
@@ -150,7 +150,7 @@ public class Compilation
       task.setJar(new File(mxmlcPath));
       task.setProject(project);
       task.setDir(project.getBaseDir());
-      task.setMaxmemory("256M"); //MXMLC needs to eat
+      task.setJvmargs(configuration.getJvmArgs());
       task.setErrorProperty("MXMLC_ERROR");
       
       Argument flexLibArgument = task.createArg();

--- a/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/FlexUnitTask.java
+++ b/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/FlexUnitTask.java
@@ -122,6 +122,11 @@ public class FlexUnitTask extends Task implements DynamicElement
       configuration.setPlayer(player);
    }
 
+   public void setJvmArgs(String jvmArgs)
+   {
+      configuration.setJvmArgs(jvmArgs);	
+   }
+
    public void setCommand(String executableFilePath)
    {
       configuration.setCommand(executableFilePath);

--- a/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/configuration/CompilationConfiguration.java
+++ b/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/configuration/CompilationConfiguration.java
@@ -16,6 +16,7 @@ public class CompilationConfiguration implements StepConfiguration
    private LibraryPaths libraries;
    private File flexHome;
    private String player;
+   private String jvmArgs;
    private File workingDir;
 
    public CompilationConfiguration()
@@ -23,6 +24,7 @@ public class CompilationConfiguration implements StepConfiguration
       sources = new SourcePaths();
       testSources = new SourcePaths();
       libraries = new LibraryPaths();
+      jvmArgs = "";
       debug = false;
    }
    
@@ -50,10 +52,20 @@ public class CompilationConfiguration implements StepConfiguration
    {
       return player;
    }
-   
+
    public void setPlayer(String player)
    {
       this.player = player;
+   }
+   
+   public String getJvmArgs()
+   {
+      return jvmArgs;	
+   }
+   
+   public void setJvmArgs(String jvmArgs)
+   {
+      this.jvmArgs = jvmArgs;	
    }
    
    public void addSource(FileSet fileset)
@@ -114,6 +126,7 @@ public class CompilationConfiguration implements StepConfiguration
       LoggingUtil.log("Using the following settings for compilation:");
       LoggingUtil.log("\tFLEX_HOME: [" + flexHome.getAbsolutePath() + "]");
       LoggingUtil.log("\tplayer: [" + player + "]");
+      LoggingUtil.log("\tjvmArgs: [" + jvmArgs + "]");
       LoggingUtil.log("\tsourceDirectories: [" + sources.getPathElements(",") + "]");
       LoggingUtil.log("\ttestSourceDirectories: [" + testSources.getPathElements(",") + "]");
       LoggingUtil.log("\tlibraries: [" + libraries.getPathElements(",") + "]");

--- a/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/configuration/TaskConfiguration.java
+++ b/FlexUnit4AntTasks/src/org/flexunit/ant/tasks/configuration/TaskConfiguration.java
@@ -17,6 +17,7 @@ public class TaskConfiguration
    private final List<String> VALID_PLAYERS = Arrays.asList(new String[]{"flash", "air"});
    
    private String player = "flash";
+   private String jvmArgs = "-Xmx256M"; //MXMLC needs to eat
    private File reportDir = null;
    private File workingDir = null;
    private boolean verbose = false;
@@ -99,6 +100,11 @@ public class TaskConfiguration
    public void setPlayer(String player)
    {
       this.player = player;
+   }
+
+   public void setJvmArgs(String jvmArgs) 
+   {
+      this.jvmArgs = jvmArgs;	
    }
 
    public void setPort(int port)
@@ -206,6 +212,9 @@ public class TaskConfiguration
       //setup player
       compilationConfiguration.setPlayer(player);
       testRunConfiguration.setPlayer(player);
+
+      //setup jvm arguments
+      compilationConfiguration.setJvmArgs(jvmArgs);
       
       //set FLEX_HOME property to respective configs
       compilationConfiguration.setFlexHome(flexHome);


### PR DESCRIPTION
Since the mxmlc command used to compile the test classes is hidden in the flexunit tag, there are some configuration options that need to be exposed, specifically the jvm arguments. This is useful when you have tests that require more than 256mb of heap space.

To use, simply add the following to the flexunit tag when executing:

jvmArgs="-Xmx512m"

This currently only affects the auto-compile of test forms.
