### PR TITLE
Adds class-level rules

### DIFF
--- a/FlexUnit4/.flexLibProperties
+++ b/FlexUnit4/.flexLibProperties
@@ -98,6 +98,7 @@
     <classEntry path="org.flexunit.internals.runners.statements.RunAftersClass"/>
     <classEntry path="org.flexunit.internals.runners.statements.RunBefores"/>
     <classEntry path="org.flexunit.internals.runners.statements.RunBeforesClass"/>
+	<classEntry path="org.flexunit.internals.runners.statements.RunClassRules"/>
     <classEntry path="org.flexunit.internals.runners.statements.SequencerWithDecoration"/>
     <classEntry path="org.flexunit.internals.runners.statements.StackAndFrameManagement"/>
     <classEntry path="org.flexunit.internals.runners.statements.StatementSequencer"/>

--- a/FlexUnit4/src/org/flexunit/internals/runners/statements/RunClassRules.as
+++ b/FlexUnit4/src/org/flexunit/internals/runners/statements/RunClassRules.as
@@ -1,0 +1,78 @@
+package org.flexunit.internals.runners.statements {
+
+	import flash.utils.getQualifiedClassName;
+	
+	import flex.lang.reflect.Field;
+	
+	import org.flexunit.internals.runners.InitializationError;
+	import org.flexunit.rules.IMethodRule;
+	import org.flexunit.runners.model.TestClass;
+	
+	/**
+	 * The <code>RunClassRules</code> is a <code>StatementSequencer</code> for potential static fields 
+	 * that have <code>Rule</code> metadata and should be run before the test class has been created.
+	 */
+	public class RunClassRules extends StatementSequencer implements IAsyncStatement {
+		
+		/**
+		 * @private
+		 */
+		private var target:Object;
+		
+		/**
+		 * @private
+		 */
+		override public function toString():String {
+			return "RunClassRules";
+		}
+		
+		/**
+		 * @private
+		 */
+		override protected function executeStep( child:* ):void {
+			super.executeStep( child );
+			
+			var statement:IAsyncStatement = withPotentialRule( child as Field, target, new StatementSequencer() );
+			try {
+				if ( statement is IMethodRule ) {
+					statement.evaluate( myToken );
+				}
+			} catch ( error:Error ) {
+				errors.push( error );
+			}
+		}
+		
+		/**
+		 * Constructor.
+		 * 
+		 * @param rules An array containing all rules that need to be executed before the class is created.
+		 * @param target The test class.
+		 */
+		public function RunClassRules( classRules:Array, target:Object ) {
+			super( classRules );
+			
+			this.target = target;
+		}
+		
+		/**
+		 * Potentially returns a new <code>IAsyncStatement</code> defined by the user on the testcase via the Rule metadata.
+		 */
+		protected function withPotentialRule( ruleField:Field, test:Object, statement:IAsyncStatement ):IAsyncStatement {
+			var testClass:Class = TestClass( test ).asClass;
+			var rule:IMethodRule;
+			
+			if (testClass[ ruleField.name ] is IMethodRule ) {
+				rule = testClass[ ruleField.name ] as IMethodRule;
+				
+				//build statement wrapper
+				statement = rule.apply( statement, null, testClass );
+			} else {
+				var ruleVal:* = testClass[ ruleField.name ];
+				var typeOfRule:String = ruleVal ? getQualifiedClassName( ruleVal ) : "null";
+				throw new InitializationError( ruleField.name + " is marked as [Rule] but does not implement IMethodRule. It appears to be " + typeOfRule );
+			}
+			
+			return statement;
+		}
+	}	
+}

--- a/FlexUnit4/src/org/flexunit/runners/BlockFlexUnit4ClassRunner.as
+++ b/FlexUnit4/src/org/flexunit/runners/BlockFlexUnit4ClassRunner.as
@@ -195,8 +195,15 @@ package org.flexunit.runners {
 		 */
 		override protected function describeChild( child:* ):IDescription {
 			//OPTIMIZATION POINT
-			var method:FrameworkMethod = FrameworkMethod( child );
-			return Description.createTestDescription( testClass.asClass, method.name, method.metadata );
+			if ( child is FrameworkMethod ) {
+				var method:FrameworkMethod = FrameworkMethod( child );
+				return Description.createTestDescription( testClass.asClass, method.name, method.metadata );
+			} else if ( child is Field ) {
+				var field:Field = Field( child );
+				return Description.createTestDescription( testClass.asClass, field.name, field.metadata );
+			} else {
+				return null;
+			}
 		}
 		
 		/**

--- a/FlexUnit4Test/src/org/flexunit/runners/RunnersSuite.as
+++ b/FlexUnit4Test/src/org/flexunit/runners/RunnersSuite.as
@@ -3,6 +3,7 @@ package org.flexunit.runners
 	import org.flexunit.runners.cases.BlockFlexUnit4ClassRunnerCase;
 	import org.flexunit.runners.cases.ParameterizedCase;
 	import org.flexunit.runners.cases.ParentRunnerCase;
+	import org.flexunit.runners.cases.RunRulesCase;
 	import org.flexunit.runners.cases.SuiteCase;
 	import org.flexunit.runners.model.ModelSuite;
 
@@ -16,5 +17,6 @@ package org.flexunit.runners
 		public var parentRunnerCase:ParentRunnerCase;
 		public var parametizedCase:ParameterizedCase;
 		public var suiteCase:SuiteCase;
+		public var rulesCase:RunRulesCase;
 	}
 }

--- a/FlexUnit4Test/src/org/flexunit/runners/cases/RunRulesCase.as
+++ b/FlexUnit4Test/src/org/flexunit/runners/cases/RunRulesCase.as
@@ -1,8 +1,17 @@
 package org.flexunit.runners.cases {
-	import org.flexunit.runners.cases.stub.SynchronousRule;
 	import org.flexunit.runners.cases.stub.AsynchronousRule;
+	import org.flexunit.runners.cases.stub.SynchronousRule;
+	import org.hamcrest.assertThat;
+	import org.hamcrest.object.equalTo;
 
 	public class RunRulesCase {
+		
+		[Rule]
+		public static var classRule1:SynchronousRule = new SynchronousRule();
+		
+		[Rule]
+		public static var classRule2:AsynchronousRule = new AsynchronousRule( 50 );
+		
 		[Rule(order=12)]
 		public var rule1:SynchronousRule = new SynchronousRule();
 
@@ -12,14 +21,47 @@ package org.flexunit.runners.cases {
 		[Rule(order=3)]
 		public var rule2:AsynchronousRule = new AsynchronousRule( 50 );
 		
+		private static var rule1RunCount:int = 0;
+		private static var rule2RunCount:int = 0;
+		private static var rule3RunCount:int = 0;
+		
+		[AfterClass]
+		public static function tearDownClass():void {
+			assertThat( classRule1.counter, equalTo( 1 ) );
+			assertThat( classRule2.counter, equalTo( 1 ) );
+			assertThat( rule1RunCount, equalTo( 3 ) );
+			assertThat( rule2RunCount, equalTo( 3 ) );
+			assertThat( rule3RunCount, equalTo( 3 ) );
+		}
+		
 		[Test]
 		public function test1():void {
-			trace("test1");
+			validateTestRules();
+			updateRunCounts();
 		}
 
 		[Test]
 		public function test2():void {
-			trace("test2");
+			validateTestRules();
+			updateRunCounts();
+		}
+		
+		[Test]
+		public function test3():void {
+			validateTestRules();
+			updateRunCounts();
+		}
+		
+		private function updateRunCounts():void {
+			rule1RunCount += rule1.counter;
+			rule2RunCount += rule2.counter;
+			rule3RunCount += rule3.counter;
+		}
+		
+		private function validateTestRules():void {
+			assertThat( rule1.counter, equalTo( 1 ) );
+			assertThat( rule2.counter, equalTo( 1 ) );
+			assertThat( rule3.counter, equalTo( 1 ) );
 		}
 	}
 }

--- a/FlexUnit4Test/src/org/flexunit/runners/cases/stub/AsynchronousRule.as
+++ b/FlexUnit4Test/src/org/flexunit/runners/cases/stub/AsynchronousRule.as
@@ -12,6 +12,8 @@ package org.flexunit.runners.cases.stub {
 	public class AsynchronousRule extends MethodRuleBase implements IMethodRule {
 		private var timer:Timer;
 		
+		public var counter:int = 0;
+		
 		public function AsynchronousRule( delay:int ) {
 			//this is an async version, note it takes a parameter
 			timer = new Timer( delay, 1 );
@@ -19,6 +21,8 @@ package org.flexunit.runners.cases.stub {
 		}
 		
 		private function timerComplete( event:TimerEvent ):void {
+			counter++;
+			
 			//Tell the framework to execute the next statement moving toward the actual test execution
 			proceedToNextStatement();
 		}

--- a/FlexUnit4Test/src/org/flexunit/runners/cases/stub/SynchronousRule.as
+++ b/FlexUnit4Test/src/org/flexunit/runners/cases/stub/SynchronousRule.as
@@ -7,11 +7,15 @@ package org.flexunit.runners.cases.stub {
 	import org.flexunit.token.ChildResult;
 	
 	public class SynchronousRule extends MethodRuleBase implements IMethodRule {
+		
+		public var counter:int = 0;
+		
 		override public function evaluate( parentToken:AsyncTestToken ):void {
 			super.evaluate( parentToken );
 			
-			//Do something synchronous if you wanted to
-
+			//Do something synchronous
+			counter++;
+			
 			//Tell the framework to execute the next statement moving toward the actual test execution
 			proceedToNextStatement();
 		}


### PR DESCRIPTION
Class rules utliize the same syntax as test rules, but are declared as public static variables and are only run once per class.

```
[Rule] public static var classRule:SynchronousRule = new SynchronousRule();
```
